### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai==0.25.0
+pip==20.2.3
+playwright==1.29.0
+pytest_playwright==0.3.0


### PR DESCRIPTION
With the exception of pytest_playwright, this file was auto-generated from the command `python3 -m pipreqs.pipreqs .`.